### PR TITLE
Attach 'code' as prefix to command rather than suffix to project_dir

### DIFF
--- a/girder_sivacor/worker_plugin/lib.py
+++ b/girder_sivacor/worker_plugin/lib.py
@@ -235,8 +235,7 @@ def _infer_run_command(submission, stage):
             command = main_file
             break
         elif os.path.exists(os.path.join(project_dir, sub_dir, "code", main_file)):
-            command = main_file
-            sub_dir = os.path.join(sub_dir, "code")
+            command = os.path.join("code", main_file)
             break
     else:
         raise ValueError("Cannot infer run command for submission")


### PR DESCRIPTION
For packages following AEA guidelines if execution script is in `project/code/` the assumption is that working directory is still `project/`