### PR TITLE
Add an endpoint for deleting a submission by the submitter

### DIFF
--- a/girder_sivacor/rest.py
+++ b/girder_sivacor/rest.py
@@ -8,12 +8,15 @@ from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
 from girder.api.rest import Resource, boundHandler, filtermodel
 from girder.constants import AccessType
-from girder.exceptions import ValidationException
-from girder.models.file import File as FileModel
-from girder.models.setting import Setting as SettingModel
-from girder.models.user import User as UserModel
+from girder.exceptions import AccessException, ValidationException
+from girder.models.collection import Collection
+from girder.models.file import File
+from girder.models.folder import Folder
+from girder.models.setting import Setting
+from girder.models.user import User
+from girder.tasks import deleteFolderTask
 from girder_jobs.constants import JobStatus
-from girder_jobs.models.job import Job as JobModel
+from girder_jobs.models.job import Job
 from zoneinfo import ZoneInfo
 
 from .settings import PluginSettings
@@ -51,6 +54,7 @@ class SIVACOR(Resource):
         self.resourceName = "sivacor"
         self.route("POST", ("submit_job",), self.submit_job)
         self.route("GET", ("image_tags",), self.get_image_tags)
+        self.route("DELETE", ("submission", ":id"), self.delete_submission)
 
     @access.user
     @autoDescribeRoute(
@@ -58,7 +62,7 @@ class SIVACOR(Resource):
         .modelParam(
             "id",
             "The ID of the file to process.",
-            model=FileModel,
+            model=File,
             level=AccessType.ADMIN,
             required=True,
             paramType="query",
@@ -71,7 +75,7 @@ class SIVACOR(Resource):
             schema=stage_schema,
         )
     )
-    @filtermodel(model=JobModel)
+    @filtermodel(model=Job)
     def submit_job(self, file, stages):
         tags = self._get_tags()
         for stage in stages:
@@ -83,18 +87,18 @@ class SIVACOR(Resource):
 
         # Job submission logic goes here
         user = self.getCurrentUser()
-        job = JobModel().createJob(
+        job = Job().createJob(
             title=f"SIVACOR Run for {file['name']} by {user['firstName']} {user['lastName']}",
             type="sivacor_submission",
             public=False,
             user=user,
         )
-        UserModel().collection.update_one(
+        User().collection.update_one(
             {"_id": user["_id"]}, {"$set": {"lastJobId": job["_id"]}}
         )
         zone = ZoneInfo("America/Chicago")
         timestamp = f"[{datetime.datetime.now().astimezone(zone).replace(microsecond=0).isoformat()}]"
-        job = JobModel().updateJob(
+        job = Job().updateJob(
             job, f"{timestamp} Preparing SIVACOR submission\n", status=JobStatus.RUNNING
         )
 
@@ -151,7 +155,7 @@ class SIVACOR(Resource):
                 "https://raw.githubusercontent.com/SIVACOR/sivacor-repo-choice"
                 "/refs/heads/main/allowed_repos.yaml"
             )
-            tags = SettingModel().get(PluginSettings.IMAGE_TAGS)
+            tags = Setting().get(PluginSettings.IMAGE_TAGS)
             try:
                 response = requests.get(source_url, timeout=10)
                 response.raise_for_status()
@@ -166,25 +170,77 @@ class SIVACOR(Resource):
 
         return tags
 
+    @access.user
+    @autoDescribeRoute(
+        Description("Delete a SIVACOR submission job and its associated data.")
+        .modelParam(
+            "id",
+            "The ID of the submission job to delete.",
+            model=Folder,
+            level=AccessType.READ,
+            required=True,
+        )
+        .param(
+            "progress",
+            "Whether to report progress during deletion.",
+            required=False,
+            dataType="boolean",
+            default=False,
+        )
+    )
+    def delete_submission(self, folder, progress):
+        # ensure that user has read access to the folder, but meta confirms he was creator
+        user = self.getCurrentUser()
+        meta = folder.get("meta", {})
+        creator_id = meta.get("creator_id")
+        if not (creator_id and str(creator_id) == str(user["_id"])):
+            raise AccessException(
+                "You do not have permission to delete '%s' submission." % folder["name"]
+            )
+        if meta.get("status") not in ("completed", "failed"):
+            raise ValidationException(
+                "Only completed or failed submissions can be deleted."
+            )
+        root = self.submission_collection(user)
+        if not root or folder["parentId"] != root["_id"]:
+            raise ValidationException("Invalid submission folder.")
+
+        job = Job().load(meta.get("job_id"), force=True)
+        if job:
+            Job().remove(job)
+        deleteFolderTask.delay(
+            str(folder["_id"]),
+            progress,
+            str(User().findOne({"admin": True})["_id"]),
+        )
+        return {"message": f"Marked submission '{folder['name']}' for deletion."}
+
+    @staticmethod
+    def submission_collection(user):
+        return Collection().filter(
+            Collection().findOne(
+                {"name": Setting().get(PluginSettings.SUBMISSION_COLLECTION_NAME)}
+            ),
+            user=user,
+        )
+
 
 @access.public
 @autoDescribeRoute(
     Description("Get submission child jobs for a given job.").modelParam(
         "id",
         "The ID of the parent job.",
-        model=JobModel,
+        model=Job,
         level=AccessType.READ,
         required=True,
     )
 )
-@filtermodel(model=JobModel)
+@filtermodel(model=Job)
 @boundHandler
 def get_submission_child_jobs(self, job):
     child_jobs = []
-    workspace_job = JobModel().findOne({"type": "celery", "args.3": str(job["_id"])})
+    workspace_job = Job().findOne({"type": "celery", "args.3": str(job["_id"])})
     if workspace_job:
         child_jobs.append(workspace_job)
-    child_jobs += list(
-        JobModel().find({"type": "celery", "args.0.job_id": str(job["_id"])})
-    )
+    child_jobs += list(Job().find({"type": "celery", "args.0.job_id": str(job["_id"])}))
     return child_jobs

--- a/tests/test_delete_submission.py
+++ b/tests/test_delete_submission.py
@@ -1,0 +1,326 @@
+import pytest
+from girder.models.folder import Folder
+from girder_jobs.constants import JobStatus
+from girder_jobs.models.job import Job
+from pytest_girder.assertions import assertStatus, assertStatusOk
+
+
+@pytest.mark.plugin("sivacor")
+def test_delete_submission_success(
+    server,
+    db,
+    user,
+    admin,
+    submission_collection,
+    eagerWorkerTasks,
+):
+    """Test successful deletion of a completed submission by the creator."""
+    # Create a job
+    job = Job().createJob(
+        title="Test Job",
+        type="sivacor_submission",
+        user=user,
+    )
+    job["status"] = JobStatus.SUCCESS
+    Job().save(job)
+
+    # Create a completed submission folder
+    submission_folder = Folder().createFolder(
+        parent=submission_collection,
+        name="test-submission",
+        parentType="collection",
+        creator=user,
+    )
+
+    # Set metadata with completed status
+    submission_folder["meta"] = {
+        "creator_id": str(user["_id"]),
+        "job_id": str(job["_id"]),
+        "status": "completed",
+    }
+    Folder().save(submission_folder)
+
+    # Delete the submission
+    resp = server.request(
+        path=f"/sivacor/submission/{submission_folder['_id']}",
+        method="DELETE",
+        user=user,
+    )
+    assertStatusOk(resp)
+    assert "message" in resp.json
+    assert "Marked submission" in resp.json["message"]
+    assert submission_folder["name"] in resp.json["message"]
+
+    # Verify job was removed
+    deleted_job = Job().load(job["_id"], force=True)
+    assert deleted_job is None
+
+
+@pytest.mark.plugin("sivacor")
+def test_delete_submission_non_creator(
+    server,
+    db,
+    user,
+    admin,
+    submission_collection,
+):
+    """Test that non-creator cannot delete a submission."""
+    # Create a job for user
+    job = Job().createJob(
+        title="Test Job",
+        type="sivacor_submission",
+        user=user,
+    )
+    job["status"] = JobStatus.SUCCESS
+    Job().save(job)
+
+    # Create a completed submission folder by user
+    submission_folder = Folder().createFolder(
+        parent=submission_collection,
+        name="user-submission",
+        parentType="collection",
+        creator=user,
+    )
+
+    # Set metadata showing user is the creator
+    submission_folder["meta"] = {
+        "creator_id": str(user["_id"]),
+        "job_id": str(job["_id"]),
+        "status": "completed",
+    }
+    Folder().save(submission_folder)
+
+    # Try to delete as admin (different user)
+    resp = server.request(
+        path=f"/sivacor/submission/{submission_folder['_id']}",
+        method="DELETE",
+        user=admin,
+    )
+    # Should return 403 Forbidden
+    assertStatus(resp, 403)
+    assert "You do not have permission to delete" in resp.json["message"]
+
+
+@pytest.mark.plugin("sivacor")
+def test_delete_submission_non_completed_status(
+    server,
+    db,
+    user,
+    admin,
+    uploads_folder,
+    submission_collection,
+):
+    """Test that submissions with non-completed/failed status cannot be deleted."""
+    # Create a submission folder with 'running' status
+    job = Job().createJob(
+        title="Test Job",
+        type="sivacor_submission",
+        user=user,
+    )
+    job["status"] = JobStatus.RUNNING
+    Job().save(job)
+
+    submission_folder = Folder().createFolder(
+        parent=submission_collection,
+        name="test-submission",
+        parentType="collection",
+        creator=user,
+    )
+
+    # Set metadata with 'running' status
+    submission_folder["meta"] = {
+        "creator_id": str(user["_id"]),
+        "job_id": str(job["_id"]),
+        "status": "running",
+    }
+    Folder().save(submission_folder)
+
+    # Try to delete the running submission
+    resp = server.request(
+        path=f"/sivacor/submission/{submission_folder['_id']}",
+        method="DELETE",
+        user=user,
+    )
+    # Should return 400 Bad Request
+    assertStatus(resp, 400)
+    assert "Only completed or failed submissions can be deleted" in resp.json["message"]
+
+
+@pytest.mark.plugin("sivacor")
+def test_delete_submission_invalid_parent_folder(
+    server,
+    db,
+    user,
+    admin,
+    uploads_folder,
+    submission_collection,
+):
+    """Test that submissions not in the submission collection cannot be deleted."""
+    # Create a job
+    job = Job().createJob(
+        title="Test Job",
+        type="sivacor_submission",
+        user=user,
+    )
+    job["status"] = JobStatus.SUCCESS
+    Job().save(job)
+
+    # Create a folder in user's uploads folder (not in submission collection)
+    wrong_folder = Folder().createFolder(
+        parent=uploads_folder,
+        name="wrong-location",
+        parentType="folder",
+        creator=user,
+    )
+
+    # Set metadata with 'completed' status
+    wrong_folder["meta"] = {
+        "creator_id": str(user["_id"]),
+        "job_id": str(job["_id"]),
+        "status": "completed",
+    }
+    Folder().save(wrong_folder)
+
+    # Try to delete the folder from wrong location
+    resp = server.request(
+        path=f"/sivacor/submission/{wrong_folder['_id']}",
+        method="DELETE",
+        user=user,
+    )
+    # Should return 400 Bad Request
+    assertStatus(resp, 400)
+    assert "Invalid submission folder" in resp.json["message"]
+
+
+@pytest.mark.plugin("sivacor")
+def test_delete_submission_failed_status(
+    server,
+    db,
+    user,
+    admin,
+    submission_collection,
+    eagerWorkerTasks,
+):
+    """Test that failed submissions can be deleted."""
+    # Create a submission folder with 'failed' status
+    job = Job().createJob(
+        title="Test Job",
+        type="sivacor_submission",
+        user=user,
+    )
+    job["status"] = JobStatus.ERROR
+    Job().save(job)
+
+    submission_folder = Folder().createFolder(
+        parent=submission_collection,
+        name="failed-submission",
+        parentType="collection",
+        creator=user,
+    )
+
+    # Set metadata with 'failed' status
+    submission_folder["meta"] = {
+        "creator_id": str(user["_id"]),
+        "job_id": str(job["_id"]),
+        "status": "failed",
+    }
+    Folder().save(submission_folder)
+
+    # Delete the failed submission
+    resp = server.request(
+        path=f"/sivacor/submission/{submission_folder['_id']}",
+        method="DELETE",
+        user=user,
+    )
+    assertStatusOk(resp)
+    assert "message" in resp.json
+    assert "Marked submission" in resp.json["message"]
+
+
+@pytest.mark.plugin("sivacor")
+def test_delete_submission_missing_creator_id(
+    server,
+    db,
+    user,
+    admin,
+    submission_collection,
+):
+    """Test that submissions without creator_id in metadata cannot be deleted."""
+    # Create a submission folder without creator_id
+    job = Job().createJob(
+        title="Test Job",
+        type="sivacor_submission",
+        user=user,
+    )
+    job["status"] = JobStatus.SUCCESS
+    Job().save(job)
+
+    submission_folder = Folder().createFolder(
+        parent=submission_collection,
+        name="no-creator-submission",
+        parentType="collection",
+        creator=user,
+    )
+
+    # Set metadata without creator_id
+    submission_folder["meta"] = {
+        "job_id": str(job["_id"]),
+        "status": "completed",
+    }
+    Folder().save(submission_folder)
+
+    # Try to delete the submission without creator_id
+    resp = server.request(
+        path=f"/sivacor/submission/{submission_folder['_id']}",
+        method="DELETE",
+        user=user,
+    )
+    # Should return 403 Forbidden
+    assertStatus(resp, 403)
+    assert "You do not have permission to delete" in resp.json["message"]
+
+
+@pytest.mark.plugin("sivacor")
+def test_delete_submission_without_job(
+    server,
+    db,
+    user,
+    admin,
+    submission_collection,
+    eagerWorkerTasks,
+):
+    """Test that submissions can be deleted even if the associated job doesn't exist."""
+    # Create a job then remove it
+    job = Job().createJob(
+        title="Test Job",
+        type="sivacor_submission",
+        user=user,
+    )
+    job_id = str(job["_id"])
+    Job().remove(job)  # Remove the job so it doesn't exist
+
+    # Create a submission folder referencing the non-existent job
+    submission_folder = Folder().createFolder(
+        parent=submission_collection,
+        name="no-job-submission",
+        parentType="collection",
+        creator=user,
+    )
+
+    # Set metadata with completed status and reference to non-existent job
+    submission_folder["meta"] = {
+        "creator_id": str(user["_id"]),
+        "job_id": job_id,
+        "status": "completed",
+    }
+    Folder().save(submission_folder)
+
+    # Delete the submission (should work even though job doesn't exist)
+    resp = server.request(
+        path=f"/sivacor/submission/{submission_folder['_id']}",
+        method="DELETE",
+        user=user,
+    )
+    assertStatusOk(resp)
+    assert "message" in resp.json
+    assert "Marked submission" in resp.json["message"]


### PR DESCRIPTION
This pull request introduces a new API endpoint for deleting SIVACOR submission jobs and their associated data, along with comprehensive tests to validate its behavior. The changes also include refactoring to use consistent Girder model imports throughout the codebase.

New API functionality for submission deletion:

* Added a `DELETE /sivacor/submission/:id` endpoint in `girder_sivacor/rest.py` to allow users to delete their own completed or failed submission jobs and associated data. The endpoint checks user permissions, submission status, and parent collection validity before deleting the job and marking the folder for deletion. [[1]](diffhunk://#diff-2d6b6d825ed5b1123162bdab76684700f77c3e04dd87288936ff76c2f03b1be7R57-R65) [[2]](diffhunk://#diff-2d6b6d825ed5b1123162bdab76684700f77c3e04dd87288936ff76c2f03b1be7R173-R245)
* Implemented the `submission_collection` static method to locate the correct collection for submissions based on plugin settings.

Comprehensive test coverage for submission deletion:

* Added `tests/test_delete_submission.py` with tests covering successful deletion, permission checks (creator vs. non-creator), status validation (only completed/failed allowed), invalid parent folder, missing creator ID, and deletion when the associated job does not exist.

Refactoring for model consistency:

* Updated imports and usage throughout `girder_sivacor/rest.py` to use Girder model classes directly (e.g., `File`, `Folder`, `Job`, `User`, `Collection`, `Setting`) instead of custom aliases, ensuring consistency and clarity. [[1]](diffhunk://#diff-2d6b6d825ed5b1123162bdab76684700f77c3e04dd87288936ff76c2f03b1be7L11-R19) [[2]](diffhunk://#diff-2d6b6d825ed5b1123162bdab76684700f77c3e04dd87288936ff76c2f03b1be7R57-R65) [[3]](diffhunk://#diff-2d6b6d825ed5b1123162bdab76684700f77c3e04dd87288936ff76c2f03b1be7L74-R78) [[4]](diffhunk://#diff-2d6b6d825ed5b1123162bdab76684700f77c3e04dd87288936ff76c2f03b1be7L86-R101) [[5]](diffhunk://#diff-2d6b6d825ed5b1123162bdab76684700f77c3e04dd87288936ff76c2f03b1be7L154-R158)
* Refactored job-related logic to use the `Job` model consistently, including job creation, updates, loading, and removal. [[1]](diffhunk://#diff-2d6b6d825ed5b1123162bdab76684700f77c3e04dd87288936ff76c2f03b1be7L86-R101) [[2]](diffhunk://#diff-2d6b6d825ed5b1123162bdab76684700f77c3e04dd87288936ff76c2f03b1be7R173-R245)

These changes collectively improve the SIVACOR plugin by enabling safe and controlled deletion of submission jobs, ensuring robust access control, and maintaining code clarity and reliability.