### PR TITLE
Inject secrets as env vars

### DIFF
--- a/girder_sivacor/rest.py
+++ b/girder_sivacor/rest.py
@@ -19,6 +19,7 @@ from girder_jobs.models.job import Job
 from zoneinfo import ZoneInfo
 
 from .settings import PluginSettings
+from .utils import encrypt_job_secrets
 from .worker_plugin.run_submission import (
     create_workspace,
     execute_workflow,
@@ -33,19 +34,37 @@ stage_schema = {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "Workflow",
     "description": "A SIVACOR replication workflow.",
-    "type": "array",
-    "items": {
-        "type": "object",
-        "properties": {
-            "image_name": {"type": "string"},
-            "main_file": {"type": "string"},
-            "image_tag": {"type": "string"},
-            "network_isolation": {"type": "boolean", "default": False},
+    "type": "object",
+    "properties": {
+        "stages": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "image_name": {"type": "string"},
+                    "main_file": {"type": "string"},
+                    "image_tag": {"type": "string"},
+                    "network_isolation": {"type": "boolean", "default": False},
+                },
+                "required": ["image_name", "main_file", "image_tag"],
+                "additionalProperties": False,
+            },
+            "minItems": 1,
         },
-        "required": ["image_name", "main_file", "image_tag"],
-        "additionalProperties": False,
+        "env_secrets": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "key": {"type": "string"},
+                    "value": {"type": "string"},
+                },
+                "required": ["key", "value"],
+                "additionalProperties": False,
+            },
+        },
     },
-    "minItems": 1,
+    "required": ["stages"],
 }
 
 
@@ -69,15 +88,18 @@ class SIVACOR(Resource):
             paramType="query",
         )
         .jsonParam(
-            "stages",
+            "workflow",
             "The defintion of replication workflow stages to execute.",
-            requireArray=True,
+            paramType="body",
+            requireObject=True,
             required=True,
             schema=stage_schema,
         )
     )
     @filtermodel(model=Job)
-    def submit_job(self, file, stages):
+    def submit_job(self, file, workflow):
+        stages = workflow.get("stages", [])
+        env_secrets = encrypt_job_secrets(workflow.get("env_secrets", []))
         tags = self._get_tags()
         for stage in stages:
             image_name = stage.get("image_name")
@@ -116,7 +138,7 @@ class SIVACOR(Resource):
             girder_job_title="Record initial arrangement"
         )
         for i, stage in enumerate(stages):
-            workflow |= execute_workflow.s(stage).set(
+            workflow |= execute_workflow.s(stage, env_secrets).set(
                 girder_job_title="Execute SIVACOR Workflow"
             )
             workflow |= run_tro.s("add_arrangement", i + 1, None).set(
@@ -126,12 +148,12 @@ class SIVACOR(Resource):
                 girder_job_title="Record user workflow TRP"
             )
         workflow |= prune_workspace.s().set(girder_job_title="Prune Workspace")
-        workflow |= run_tro.s(
-            "add_arrangement", len(stages) + 1, "is_pruned"
-        ).set(girder_job_title="Record final pruned arrangement")
-        workflow |= run_tro.s(
-            "prune_performance", len(stages), "is_pruned"
-        ).set(girder_job_title="Record workspace prune TRP")
+        workflow |= run_tro.s("add_arrangement", len(stages) + 1, "is_pruned").set(
+            girder_job_title="Record final pruned arrangement"
+        )
+        workflow |= run_tro.s("prune_performance", len(stages), "is_pruned").set(
+            girder_job_title="Record workspace prune TRP"
+        )
         workflow |= run_tro.s("sign", 0, None).set(girder_job_title="Sign TRO")
         workflow |= upload_workspace.s().set(
             girder_job_title="Upload Replicated Package"

--- a/girder_sivacor/utils.py
+++ b/girder_sivacor/utils.py
@@ -1,0 +1,34 @@
+import os
+import json
+import base64
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+MASTER_KEY_HEX = os.environ.get(
+    "MASTER_KEY_HEX", "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+)
+_master_key = bytes.fromhex(MASTER_KEY_HEX)
+MASTER_AES = AESGCM(_master_key)
+
+
+def encrypt_job_secrets(env_secrets_list):
+    """
+    Encrypts a list of secrets using Envelope Encryption.
+    """
+    job_key = AESGCM.generate_key(bit_length=256)
+    job_aes = AESGCM(job_key)
+
+    plaintext_data = json.dumps(env_secrets_list).encode("utf-8")
+    nonce_data = os.urandom(12)  # GCM needs a 12-byte nonce
+    encrypted_secrets = job_aes.encrypt(nonce_data, plaintext_data, None)
+
+    nonce_key = os.urandom(12)
+    wrapped_job_key = MASTER_AES.encrypt(nonce_key, job_key, None)
+
+    return {
+        "encrypted_secrets": base64.b64encode(nonce_data + encrypted_secrets).decode(
+            "utf-8"
+        ),
+        "wrapped_job_key": base64.b64encode(nonce_key + wrapped_job_key).decode(
+            "utf-8"
+        ),
+    }

--- a/girder_sivacor/worker_plugin/lib.py
+++ b/girder_sivacor/worker_plugin/lib.py
@@ -1,3 +1,4 @@
+import base64
 import functools
 import io
 import json
@@ -10,6 +11,7 @@ import stat
 import tempfile
 import time
 import zipfile
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from pathlib import Path
 from threading import Event, Thread
 
@@ -28,6 +30,13 @@ from girder.models.user import User
 from girder.settings import SettingKey
 from girder.utility import RequestBodyStream
 
+MASTER_KEY_HEX = os.environ.get(
+    "MASTER_KEY_HEX", "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+)
+_master_key = bytes.fromhex(MASTER_KEY_HEX)
+MASTER_AES = AESGCM(_master_key)
+MASK = "***SECRET_REDACTED***"
+
 
 class NpEncoder(json.JSONEncoder):
     def default(self, obj):
@@ -38,6 +47,21 @@ class NpEncoder(json.JSONEncoder):
         if isinstance(obj, np.ndarray):
             return obj.tolist()
         return super(NpEncoder, self).default(obj)
+
+
+def decrypt_job_secrets(encrypted_secrets_b64, wrapped_job_key_b64):
+    """
+    Unwraps the job key and decrypts the secrets.
+    """
+    # Decode and extract nonces (first 12 bytes)
+    key_payload = base64.b64decode(wrapped_job_key_b64)
+    job_key = MASTER_AES.decrypt(key_payload[:12], key_payload[12:], None)
+
+    secrets_payload = base64.b64decode(encrypted_secrets_b64)
+    job_aes = AESGCM(job_key)
+    decrypted_json = job_aes.decrypt(secrets_payload[:12], secrets_payload[12:], None)
+
+    return json.loads(decrypted_json.decode("utf-8"))
 
 
 def annotate_item_type(file_obj: dict, item_type: str) -> None:
@@ -92,12 +116,13 @@ def _redis_client_sync() -> redis.Redis:
 
 
 class LogPublisher(Thread):
-    def __init__(self, container_name, channel):
+    def __init__(self, container_name, channel, known_secrets):
         super().__init__()
         self.container_name = container_name
         self.channel = channel
         self.client = docker.from_env()
         self._stop_event = Event()
+        self.known_secrets = known_secrets
         self.daemon = True  # Allows Python to exit even if this thread is running
 
     def run(self):
@@ -115,6 +140,8 @@ class LogPublisher(Thread):
                     break
 
                 log_line = log_line_bytes.decode("utf-8").strip()
+                for secret in self.known_secrets:
+                    log_line = log_line.replace(secret, MASK)
                 # Use the synchronous client for publishing
                 _redis_client_sync().publish(self.channel, log_line)
         except Exception as e:
@@ -381,7 +408,7 @@ def _infer_run_command(submission, stage):
     return entrypoint, command, sub_dir, home_dir
 
 
-def recorded_run(submission, stage, task=None):
+def recorded_run(submission, stage, env_vars, task=None):
     cli = docker.from_env()
     info = cli.info()
     cpu_info = cpuinfo.get_cpu_info()
@@ -395,10 +422,20 @@ def recorded_run(submission, stage, task=None):
         "NCPU": info.get("NCPU"),
         "Processor": cpu_info.get("brand_raw"),
     }
+    user_env = {
+        _["key"]: _["value"]
+        for _ in decrypt_job_secrets(
+            env_vars["encrypted_secrets"], env_vars["wrapped_job_key"]
+        )
+    }
+    known_secrets = list(user_env.values())
 
     def logging_worker(log_queue, container):
         for line in container.logs(stream=True):
-            log_queue.put(line.decode("utf-8").strip(), block=False)
+            line = line.decode("utf-8", errors="ignore").strip()
+            for secret in known_secrets:
+                line = line.replace(secret, MASK)
+            log_queue.put(line, block=False)
 
     task = task or DummyTask
     log_queue = queue.Queue()
@@ -456,6 +493,17 @@ def recorded_run(submission, stage, task=None):
         user = f"{os.getuid()}:{os.getgid()}"
         read_only = True
 
+    environment = {
+        "TMPDIR": "/tmp",
+        "TEMP": "/tmp",
+        "TMP": "/tmp",
+        "HOME": home_dir,
+        "R_LIBS": os.path.join(home_dir, "R", "library"),
+        "R_LIBS_USER": os.path.join(home_dir, "R", "library"),
+        "MLM_LICENSE_FILE": "27007@rtlicense1.uits.indiana.edu",
+    }
+    environment.update(user_env)
+
     container = cli.containers.create(
         image=image_reference,
         entrypoint=entrypoint,
@@ -466,22 +514,14 @@ def recorded_run(submission, stage, task=None):
         read_only=read_only,
         working_dir=os.path.join(target_workspace_dir, "project", sub_dir),
         user=user,
-        environment={
-            "TMPDIR": "/tmp",
-            "TEMP": "/tmp",
-            "TMP": "/tmp",
-            "HOME": home_dir,
-            "R_LIBS": os.path.join(home_dir, "R", "library"),
-            "R_LIBS_USER": os.path.join(home_dir, "R", "library"),
-            "MLM_LICENSE_FILE": "27007@rtlicense1.uits.indiana.edu",
-        },
+        environment=environment,
     )
 
     logging_thread = Thread(target=logging_worker, args=(log_queue, container))
     with tempfile.TemporaryDirectory() as container_temp_path:
         dstats_tmppath = os.path.join(container_temp_path, "dockerstats")
         stats_thread = DockerStatsCollectorThread(container, dstats_tmppath)
-        publisher = LogPublisher(container.name, f"docker:logs:{creator_id}")
+        publisher = LogPublisher(container.name, f"docker:logs:{creator_id}", known_secrets)
 
         # Job output must come from stdout/stderr
         container.start()
@@ -594,6 +634,8 @@ def recorded_run(submission, stage, task=None):
                                 log_content = log_content.decode(
                                     "utf-8", errors="ignore"
                                 )
+                                for secret in known_secrets:
+                                    log_content = log_content.replace(secret, MASK)
                                 stata_err = stata_error(log_content)
                         break
 
@@ -603,6 +645,19 @@ def recorded_run(submission, stage, task=None):
             if not os.path.isfile(target_file):
                 print(f"{key} file not found, skipping...")
                 continue
+
+            # obfuscate secrets in the log file before uploading,
+            # line by line to avoid memory issues with large files
+            with (
+                open(target_file, "rb") as fp,
+                open(target_file + ".tmp", "wb") as out_f,
+            ):
+                for line in fp:
+                    line_decoded = line.decode("utf-8", errors="ignore")
+                    for secret in known_secrets:
+                        line_decoded = line_decoded.replace(secret, MASK)
+                    out_f.write(line_decoded.encode("utf-8"))
+            os.replace(target_file + ".tmp", target_file)
 
             log_file = f"/tmp/{key}-{submission['job_id']}"
             log_obj = None

--- a/girder_sivacor/worker_plugin/run_submission.py
+++ b/girder_sivacor/worker_plugin/run_submission.py
@@ -468,7 +468,7 @@ def run_tro(task, submission, action, inumber, condition):
 
 @app.task(queue="local", bind=True)
 @job_check
-def execute_workflow(task, submission, stage):
+def execute_workflow(task, submission, stage, env_vars):
     job = Job().load(submission["job_id"], force=True)
     job = Job().updateJob(
         job,
@@ -479,7 +479,7 @@ def execute_workflow(task, submission, stage):
         # Placeholder for actual workflow execution logic
 
         start_time = datetime.datetime.now()
-        ret = recorded_run(submission, stage, task=task)
+        ret = recorded_run(submission, stage, env_vars, task=task)
         if ret["StatusCode"] == -123:
             print("Termination requested, stopping execution.")
             if task.request.chain:

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ with open("README.md") as readme_file:
     readme = readme_file.read()
 
 requirements = [
+    "cryptography",
     "girder>=5.0.3",
     "girder-async-routes>=0.1.3",
     "girder-oauth>=5.0.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,7 +130,7 @@ def upload_test_file(uploads_folder, user, filename):
         )
 
 
-def submit_sivacor_job(server, user, file_obj, stages):
+def submit_sivacor_job(server, user, file_obj, stages, secrets=None, exception=False):
     """
     Helper function to submit a SIVACOR job.
 
@@ -150,8 +150,15 @@ def submit_sivacor_job(server, user, file_obj, stages):
         user=user,
         params={
             "id": str(file_obj["_id"]),
-            "stages": json.dumps(stages),
         },
+        body=json.dumps(
+            {
+                "stages": stages,
+                "env_secrets": secrets or [],
+            }
+        ),
+        type="application/json",
+        exception=exception,
     )
 
 
@@ -180,9 +187,7 @@ def get_submission_folder(server, user, job_id, submission_collection):
     )
 
 
-def assert_submission_metadata(
-    metadata, user, job_id, stages, status, expected_files
-):
+def assert_submission_metadata(metadata, user, job_id, stages, status, expected_files):
     """
     Helper function to assert submission folder metadata.
 

--- a/tests/test_R.py
+++ b/tests/test_R.py
@@ -1,10 +1,17 @@
+import os
+import tarfile
+import tempfile
+
 import pytest
+from girder.models.file import File
+from girder_jobs.constants import JobStatus
 from pytest_girder.assertions import assertStatusOk
+
 from .conftest import (
-    upload_test_file,
-    submit_sivacor_job,
-    get_submission_folder,
     assert_submission_metadata,
+    get_submission_folder,
+    submit_sivacor_job,
+    upload_test_file,
 )
 
 
@@ -35,7 +42,9 @@ def test_simple_run(
     fobj = upload_test_file(uploads_folder, user, "with_space_R.zip")
 
     # Submit SIVACOR R job
-    stages = [{"image_name": "rocker/r-ver", "image_tag": "4.3.1", "main_file": "main.R"}]
+    stages = [
+        {"image_name": "rocker/r-ver", "image_tag": "4.3.1", "main_file": "main.R"}
+    ]
     resp = submit_sivacor_job(server, user, fobj, stages)
     assertStatusOk(resp)
     job = resp.json
@@ -63,3 +72,67 @@ def test_simple_run(
         "completed",
         expected_files,
     )
+
+
+@pytest.mark.plugin("sivacor")
+def test_secrets(
+    server,
+    db,
+    user,
+    eagerWorkerTasks,
+    fsAssetstore,
+    patched_gpg,
+    uploads_folder,
+    submission_collection,
+):
+    """Test if secrets are properly passed to the R job."""
+    main_file = "main.R"
+    stages = [
+        {"image_name": "rocker/r-ver", "image_tag": "4.3.1", "main_file": main_file}
+    ]
+    secrets = [{"key": "SECRET", "value": "my_secret_value"}]
+    with (
+        tempfile.NamedTemporaryFile(suffix=".tar.gz") as temp_archive,
+        tempfile.TemporaryDirectory() as temp_dir,
+    ):
+        with open(os.path.join(temp_dir, main_file), "w") as f:
+            f.write("cat(Sys.getenv('SECRET'))\n")
+
+        with tarfile.open(temp_archive.name, "w:gz") as tar:
+            tar.add(temp_dir, arcname=".")
+
+        # Upload the modified archive
+        fobj = upload_test_file(uploads_folder, user, temp_archive.name)
+
+    resp = submit_sivacor_job(server, user, fobj, stages, secrets=secrets)
+    assertStatusOk(resp)
+    job = resp.json
+
+    # Verify job failed due to command failure (since the secret value will cause an unrecognized command)
+    # but the secret value should not appear in the stdout, nor job logs
+    resp = server.request(
+        path=f"/job/{job['_id']}",
+        method="GET",
+        user=user,
+    )
+    assertStatusOk(resp)
+    job = resp.json
+    assert job["status"] == JobStatus.SUCCESS
+
+    log_content = "".join(job["log"])
+    assert "my_secret_value" not in log_content
+
+    # Get submission folder and verify metadata
+    resp = get_submission_folder(server, user, job["_id"], submission_collection)
+    assertStatusOk(resp)
+    assert len(resp.json) == 1
+
+    submission_folder = resp.json[0]
+    metadata = submission_folder["meta"]
+
+    # Verify stdout does not contain the secret value but contains the expected output
+    stdout = File().load(metadata["stdout_file_id"], force=True)
+    with File().open(stdout) as f:
+        stdout_content = f.read()
+    assert "my_secret_value" not in stdout_content.decode("utf-8")
+    assert "SECRET_REDACTED" in stdout_content.decode("utf-8")

--- a/tests/test_stata.py
+++ b/tests/test_stata.py
@@ -1,14 +1,17 @@
-import json
+import os
+import tarfile
+import tempfile
 import pytest
 from girder.models.file import File
 from girder_jobs.constants import JobStatus
 from girder_jobs.models.job import Job
 from pytest_girder.assertions import assertStatusOk
+
 from .conftest import (
-    upload_test_file,
-    submit_sivacor_job,
-    get_submission_folder,
     assert_submission_metadata,
+    get_submission_folder,
+    submit_sivacor_job,
+    upload_test_file,
 )
 
 
@@ -101,16 +104,7 @@ def test_error_detection(
     fobj = upload_test_file(uploads_folder, user, "test_stata.tar.gz")
 
     # Submit SIVACOR Stata job (expecting failure)
-    resp = server.request(
-        path="/sivacor/submit_job",
-        method="POST",
-        user=user,
-        params={
-            "id": str(fobj["_id"]),
-            "stages": json.dumps(stages),
-        },
-        exception=True,
-    )
+    resp = submit_sivacor_job(server, user, fobj, stages, exception=True)
     assertStatusOk(resp)
     job = resp.json
 
@@ -172,17 +166,7 @@ def test_dual_stdout(
     assert uploads_folder is not None
     fobj = upload_test_file(uploads_folder, user, "dual_output.zip")
 
-    # Submit SIVACOR Stata job (expecting failure)
-    resp = server.request(
-        path="/sivacor/submit_job",
-        method="POST",
-        user=user,
-        params={
-            "id": str(fobj["_id"]),
-            "stages": json.dumps(stages),
-        },
-        exception=True,
-    )
+    resp = submit_sivacor_job(server, user, fobj, stages, exception=False)
     assertStatusOk(resp)
     job = resp.json
 
@@ -206,3 +190,71 @@ def test_dual_stdout(
     stdout_content_decoded = stdout_content.decode("utf-8")
     assert "optimization converged" in stdout_content_decoded
     assert "Additional log content from main.log" in stdout_content_decoded
+
+
+@pytest.mark.plugin("sivacor")
+def test_secrets(
+    server,
+    db,
+    user,
+    eagerWorkerTasks,
+    fsAssetstore,
+    patched_gpg,
+    uploads_folder,
+    submission_collection,
+):
+    """Test if secrets are properly passed to the Stata job."""
+    image_name = "dataeditors/stata18_5-mp"
+    image_tag = "2025-02-26"
+    main_file = "check_secrets.do"
+    stages = [
+        {"image_name": image_name, "image_tag": image_tag, "main_file": main_file}
+    ]
+    secrets = [{"key": "SECRET", "value": "my_secret_value"}]
+    with (
+        tempfile.NamedTemporaryFile(suffix=".tar.gz") as temp_archive,
+        tempfile.TemporaryDirectory() as temp_dir,
+    ):
+        with open(os.path.join(temp_dir, main_file), "w") as f:
+            f.write("local x : env SECRET\n")
+            f.write('display "`x\'"fail.do\n')
+
+        with tarfile.open(temp_archive.name, "w:gz") as tar:
+            tar.add(temp_dir, arcname=".")
+
+        # Upload the modified archive
+        fobj = upload_test_file(uploads_folder, user, temp_archive.name)
+
+    resp = submit_sivacor_job(server, user, fobj, stages, secrets=secrets)
+    assertStatusOk(resp)
+    job = resp.json
+
+    # Verify job failed due to command failure (since the secret value will cause an unrecognized command)
+    # but the secret value should not appear in the stdout, nor job logs
+    resp = server.request(
+        path=f"/job/{job['_id']}",
+        method="GET",
+        user=user,
+    )
+    assertStatusOk(resp)
+    job = resp.json
+    assert job["status"] == JobStatus.ERROR
+
+    log_content = "".join(job["log"])
+    assert "my_secret_value" not in log_content
+    assert "SECRET_REDACTED" in log_content
+
+    # Get submission folder and verify metadata
+    resp = get_submission_folder(server, user, job["_id"], submission_collection)
+    assertStatusOk(resp)
+    assert len(resp.json) == 1
+
+    submission_folder = resp.json[0]
+    metadata = submission_folder["meta"]
+
+    # Verify stdout does not contain the secret value but contains the expected output
+    stdout = File().load(metadata["stdout_file_id"], force=True)
+    with File().open(stdout) as f:
+        stdout_content = f.read()
+    assert "my_secret_value" not in stdout_content.decode("utf-8")
+    assert "SECRET_REDACTED" in stdout_content.decode("utf-8")


### PR DESCRIPTION
Allow to pass key/value pairs that are used to pass secrets via env vars into running containers. Envelop-encrypt them immediately after receiving and pass encrypted base64 around. Only decrypt while running container. Do not ever store them. Redact outputs from file, job, notification logs respectively.

Fixes #18