### PR TITLE
Use a dedicated volume for /tmp in containers

### DIFF
--- a/girder_sivacor/worker_plugin/__init__.py
+++ b/girder_sivacor/worker_plugin/__init__.py
@@ -205,6 +205,7 @@ def set_submission_status(event: events.Event) -> None:
                 str(e),
             )
         shutil.rmtree(f"/tmp/workspace-{submission_folder['_id']}", ignore_errors=True)
+        shutil.rmtree(f"/tmp/tmp-{submission_folder['_id']}", ignore_errors=True)
     else:
         submission_status = "processing"
     Folder().collection.update_one(

--- a/girder_sivacor/worker_plugin/lib.py
+++ b/girder_sivacor/worker_plugin/lib.py
@@ -460,10 +460,9 @@ def recorded_run(submission, stage, env_vars, task=None):
             read_only=False,
         ),
         docker.types.Mount(
-            type="tmpfs",
-            source=None,
+            source=os.path.join(host_tmp_root, submission["tmp_dir"].lstrip("/")),
             target="/tmp",
-            tmpfs_size="1G",
+            type="bind",
         ),
     ]
     if stata_license_hostpath := os.environ.get("STATA_LICENSE_HOSTPATH"):
@@ -521,7 +520,9 @@ def recorded_run(submission, stage, env_vars, task=None):
     with tempfile.TemporaryDirectory() as container_temp_path:
         dstats_tmppath = os.path.join(container_temp_path, "dockerstats")
         stats_thread = DockerStatsCollectorThread(container, dstats_tmppath)
-        publisher = LogPublisher(container.name, f"docker:logs:{creator_id}", known_secrets)
+        publisher = LogPublisher(
+            container.name, f"docker:logs:{creator_id}", known_secrets
+        )
 
         # Job output must come from stdout/stderr
         container.start()

--- a/girder_sivacor/worker_plugin/run_submission.py
+++ b/girder_sivacor/worker_plugin/run_submission.py
@@ -255,6 +255,11 @@ def create_workspace(task, submission):
     )
 
     try:
+        submission["tmp_dir"] = f"/tmp/tmp-{submission['folder_id']}"
+        os.makedirs(submission["tmp_dir"], exist_ok=False)
+        # add sticky bit to tmp_dir
+        os.chmod(submission["tmp_dir"], 0o1777)
+
         workspace_dir = f"/tmp/workspace-{submission['folder_id']}"
         submission["workspace_dir"] = workspace_dir
         project_dir = get_project_dir(submission)
@@ -673,6 +678,7 @@ def upload_workspace(task, submission):
 
 @app.task(queue="local")
 def finalize_job(submission):
+    shutil.rmtree(submission["tmp_dir"], ignore_errors=True)
     shutil.rmtree(submission["workspace_dir"], ignore_errors=True)
     job = Job().load(submission["job_id"], force=True)
     if job["status"] == JobStatus.RUNNING:


### PR DESCRIPTION
This pull request introduces improvements to how temporary directories are managed for submission processing, ensuring better isolation and cleanup of resources. The main changes focus on creating a dedicated temporary directory per submission, updating how this directory is mounted into containers, and ensuring proper cleanup after job completion.

**Temporary directory management improvements:**

* A unique `tmp_dir` is now created for each submission in `create_workspace`, with appropriate permissions set (sticky bit for security). (`girder_sivacor/worker_plugin/run_submission.py`)
* The dedicated `tmp_dir` is now mounted into the container as a bind mount instead of a tmpfs, improving compatibility and persistence. (`girder_sivacor/worker_plugin/lib.py`)

**Resource cleanup enhancements:**

* The submission-specific `tmp_dir` is now explicitly deleted after job completion in `finalize_job`, preventing resource leakage. (`girder_sivacor/worker_plugin/run_submission.py`)
* Additional cleanup of the submission-specific `tmp_dir` is performed in error handling within `set_submission_status`. (`girder_sivacor/worker_plugin/__init__.py`)

**Minor code improvements:**

* Minor formatting fix for the instantiation of `LogPublisher` for readability. (`girder_sivacor/worker_plugin/lib.py`)