### PR TITLE
Add support for account approval workflow with custom emails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,25 @@ RUN cd /src && \
   cd ../../ && \
   python -m build .
 
+# Temporary OAuth
+RUN cd /tmp && \
+  git clone https://github.com/xarthisius/girder -b oauth_approve && \
+  cd girder/plugins/oauth/girder_oauth/web_client && \
+  npm install && \
+  npm run build && \
+  cd ../../ && \
+  python -m build . && \
+  cp dist/* /src/dist/ && \
+  cd /tmp/girder && \
+  git checkout auth_email_events && \
+  cd girder/web && \
+  npm i && \
+  npm run build && \
+  cd ../../ && \
+  python -m build . && \
+  cp dist/* /src/dist/ && \
+  cd /tmp && rm -rf girder
+
 RUN python -m pip wheel --wheel-dir=/src/dist pylibacl
 
 FROM python:3.12-slim
@@ -66,7 +85,7 @@ RUN apt-get update -qy \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-RUN python3 -m pip install \
+RUN python3 -m pip install --no-cache-dir \
   'celery>=5.5.2' \
   'girder>=5.0.0a8.dev39' \
   'girder-user-quota>=5.0.0a8.dev39'

--- a/girder_sivacor/__init__.py
+++ b/girder_sivacor/__init__.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 from pathlib import Path
 
@@ -10,7 +11,7 @@ from girder.exceptions import ValidationException
 from girder.models.folder import Folder
 from girder.models.user import User
 from girder.plugin import GirderPlugin, getPlugin, registerPluginStaticContent
-from girder.utility import setting_utilities
+from girder.utility import mail_utils, setting_utilities
 from girder.utility.model_importer import ModelImporter
 from girder_jobs.constants import JobStatus
 from girder_jobs.models.job import Job as JobModel
@@ -20,6 +21,10 @@ from girder_oauth.settings import PluginSettings as OAuthSettings
 from .auth.orcid import ORCID
 from .rest import SIVACOR, get_submission_child_jobs
 from .settings import PluginSettings
+from .worker_plugin import (
+    _createMessage,
+    _sendmail
+)
 
 logger = logging.getLogger(__name__)
 
@@ -97,6 +102,59 @@ def create_uploads_folder(event: events.Event) -> None:
     folderModel.setUserAccess(uploads_folder, user, level=AccessType.ADMIN, save=True)
 
 
+def send_approval_email(event: events.Event) -> None:
+    logger.info("In send_approval")
+    user = event.info["user"]
+    context = {
+        "user": user,
+        "base_url": "https://submit.sivacor.org",
+        "docs_url": "https://docs.sivacor.org",
+        "feedback_url": "https://feedback.sivacor.org",
+        "current_year": datetime.datetime.now().year,
+        "logo_url": "https://submit.sivacor.org/sivacor_logo_notext_trans.png",
+        "submission_url": "https://submit.sivacor.org/",
+    }
+    text_content = (
+        f"Hello Admin,\n\n"
+        "Someone has registered a new account that needs admin approval.\n"
+        f"Login: {user['login']}\n"
+        f"Email: {user['email']}\n"
+        f"Name: {user['firstName']} {user['lastName']}"
+    )
+    rendered_html = mail_utils.renderTemplate("account_approval.mako", context)
+    to = [u["email"] for u in User().getAdmins()]
+    logger.info("creating message")
+    msg, recipients = _createMessage(
+        "Account pending approval", text_content, rendered_html, to, None
+    )
+    events.trigger("_sendmail", info={"message": msg, "recipients": recipients})
+    event.preventDefault()
+
+
+def send_approved_email(event: events.Event) -> None:
+    user = event.info["user"]
+    context = {
+        "user": user,
+        "base_url": "https://submit.sivacor.org",
+        "docs_url": "https://docs.sivacor.org",
+        "feedback_url": "https://feedback.sivacor.org",
+        "current_year": datetime.datetime.now().year,
+        "logo_url": "https://submit.sivacor.org/sivacor_logo_notext_trans.png",
+        "submission_url": "https://submit.sivacor.org/",
+    }
+    text_content = (
+        f"Hello {user['firstName']} {user['lastName']},\n\n"
+        "Your account has been approved. You may now login."
+    )
+    rendered_html = mail_utils.renderTemplate("account_approved.mako", context)
+    to = [user["email"]]
+    msg, recipients = _createMessage(
+        "Account pending approval", text_content, rendered_html, to, None
+    )
+    events.trigger("_sendmail", info={"message": msg, "recipients": recipients})
+    event.preventDefault()
+
+
 @access.public(scope=TokenScope.DATA_READ)
 @filtermodel(model=Folder)
 @boundHandler
@@ -159,6 +217,10 @@ class SIVACORPlugin(GirderPlugin):
     def load(self, info):
         from girder.api.v1.folder import Folder as FolderResource
 
+        events.unbind("_sendmail", "core.email")
+        events.bind("_sendmail", "sivacor", _sendmail)
+        events.bind("email.approval", "sivacor", send_approval_email)
+        events.bind("email.approved", "sivacor", send_approved_email)
         events.bind("model.user.save.created", "sivacor", create_uploads_folder)
         events.bind("rest.get.folder.before", "sivacor", search_with_job_id)
         ModelImporter.model("user").exposeFields(
@@ -185,7 +247,9 @@ class SIVACORPlugin(GirderPlugin):
             required=False,
             dataType="string",
         )
-
+        template_dir = (Path(__file__).parent / "mail_templates").as_posix()
+        logger.warning(f"Adding {template_dir} as template directory")
+        mail_utils.addTemplateDirectory(template_dir)
         registerPluginStaticContent(
             plugin="sivacor",
             css=["/style.css"],

--- a/girder_sivacor/mail_templates/account_approval.mako
+++ b/girder_sivacor/mail_templates/account_approval.mako
@@ -1,0 +1,125 @@
+## -*- coding: utf-8 -*-
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>SIVACOR: Account pending approval</title>
+    <!--[if mso]>
+    <style type="text/css">
+        body, table, td {font-family: Arial, sans-serif !important;}
+    </style>
+    <![endif]-->
+</head>
+<body style="margin: 0; padding: 0; font-family: 'Roboto', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif; background-color: #fafafa; color: #212121; line-height: 1.5; font-size: 16px;">
+    <!-- Email Container -->
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color: #fafafa; padding: 24px 0;">
+        <tr>
+            <td align="center">
+                <!-- Content Wrapper -->
+                <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="600" style="max-width: 600px; background-color: #ffffff; box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24); border-radius: 12px; overflow: hidden;">
+
+                    <!-- Header -->
+                    <tr>
+                        <td style="background: linear-gradient(135deg, #1976d2 0%, #1565c0 100%); padding: 32px 24px; text-align: center; position: relative;">
+                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                                <tr>
+                                    <td align="center">
+                                        <!-- Logo and Title -->
+                                        <table role="presentation" cellspacing="0" cellpadding="0" border="0">
+                                            <tr>
+                                                <td align="center" style="padding-bottom: 16px;">
+                                                    % if logo_url:
+                                                    <img src="${logo_url}" alt="SIVACOR Logo" width="60" height="60" style="display: block; border: 0; border-radius: 8px;">
+                                                    % endif
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td align="center">
+                                                    <h1 style="margin: 0; font-size: 28px; font-weight: 500; color: #ffffff; letter-spacing: 0.5px;">SIVACOR</h1>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td align="center" style="padding-top: 8px;">
+                                                    <p style="margin: 0; font-size: 14px; color: rgba(255, 255, 255, 0.9); line-height: 1.4;">
+                                                        Scalable Infrastructure for Validation of<br>Computational Social Science Research
+                                                    </p>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+
+                    <!-- Main Content -->
+                    <tr>
+                        <td style="padding: 32px 24px;">
+                            <h2 style="margin: 0 0 16px 0; font-size: 20px; font-weight: 500; color: #212121;">
+                                Hello Admin,
+                            </h2>
+                            <p style="margin: 0 0 16px 0; color: #212121; font-size: 16px; line-height: 1.6;">
+                                Someone has registered a new account that needs admin approval.
+                            </p>
+
+                            <!-- Job Details Card -->
+                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color: #f5f5f5; border-radius: 8px; margin: 24px 0;">
+                                <tr>
+                                    <td style="padding: 20px;">
+                                        <h3 style="margin: 0 0 16px 0; font-size: 16px; font-weight: 500; color: #1976d2;">User Details</h3>
+
+                                        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                                            <tr>
+                                                <td style="padding: 8px 0; color: #757575; font-size: 14px; width: 140px;">Login:</td>
+                                                <td style="padding: 8px 0; color: #212121; font-size: 14px; font-family: 'Courier New', monospace; word-break: break-all;">${user.get('login')}</td>
+                                            </tr>
+                                            <tr>
+                                                <td style="padding: 8px 0; color: #757575; font-size: 14px;">Email:</td>
+                                                <td style="padding: 8px 0; color: #212121; font-size: 14px;">${user.get('email')}</td>
+                                            </tr>
+                                            <tr>
+                                                <td style="padding: 8px 0; color: #757575; font-size: 14px;">Name:</td>
+                                                <td style="padding: 8px 0; color: #212121; font-size: 14px;">${user.get('firstName')} ${user.get('lastName')}</td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+
+                    <!-- Footer -->
+                    <tr>
+                        <td style="background-color: #f5f5f5; padding: 24px; text-align: center; border-top: 1px solid #e0e0e0;">
+                            <p style="margin: 0 0 8px 0; color: #757575; font-size: 12px;">
+                                This is an automated notification from SIVACOR
+                            </p>
+                            <p style="margin: 0 0 16px 0; color: #757575; font-size: 12px;">
+                                © ${current_year} SIVACOR. All rights reserved.
+                            </p>
+                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center">
+                                <tr>
+                                    <td style="padding: 0 8px;">
+                                        <a href="${base_url}" style="color: #1976d2; text-decoration: none; font-size: 12px;">Dashboard</a>
+                                    </td>
+                                    <td style="padding: 0 8px; color: #e0e0e0;">|</td>
+                                    <td style="padding: 0 8px;">
+                                        <a href="${docs_url}" style="color: #1976d2; text-decoration: none; font-size: 12px;">Documentation</a>
+                                    </td>
+                                    <td style="padding: 0 8px; color: #e0e0e0;">|</td>
+                                    <td style="padding: 0 8px;">
+                                        <a href="mailto:support@sivacor.org" style="color: #1976d2; text-decoration: none; font-size: 12px;">Support</a>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/girder_sivacor/mail_templates/account_approved.mako
+++ b/girder_sivacor/mail_templates/account_approved.mako
@@ -1,0 +1,104 @@
+## -*- coding: utf-8 -*-
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>SIVACOR: Account approved</title>
+    <!--[if mso]>
+    <style type="text/css">
+        body, table, td {font-family: Arial, sans-serif !important;}
+    </style>
+    <![endif]-->
+</head>
+<body style="margin: 0; padding: 0; font-family: 'Roboto', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif; background-color: #fafafa; color: #212121; line-height: 1.5; font-size: 16px;">
+    <!-- Email Container -->
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color: #fafafa; padding: 24px 0;">
+        <tr>
+            <td align="center">
+                <!-- Content Wrapper -->
+                <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="600" style="max-width: 600px; background-color: #ffffff; box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24); border-radius: 12px; overflow: hidden;">
+
+                    <!-- Header -->
+                    <tr>
+                        <td style="background: linear-gradient(135deg, #1976d2 0%, #1565c0 100%); padding: 32px 24px; text-align: center; position: relative;">
+                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                                <tr>
+                                    <td align="center">
+                                        <!-- Logo and Title -->
+                                        <table role="presentation" cellspacing="0" cellpadding="0" border="0">
+                                            <tr>
+                                                <td align="center" style="padding-bottom: 16px;">
+                                                    % if logo_url:
+                                                    <img src="${logo_url}" alt="SIVACOR Logo" width="60" height="60" style="display: block; border: 0; border-radius: 8px;">
+                                                    % endif
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td align="center">
+                                                    <h1 style="margin: 0; font-size: 28px; font-weight: 500; color: #ffffff; letter-spacing: 0.5px;">SIVACOR</h1>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td align="center" style="padding-top: 8px;">
+                                                    <p style="margin: 0; font-size: 14px; color: rgba(255, 255, 255, 0.9); line-height: 1.4;">
+                                                        Scalable Infrastructure for Validation of<br>Computational Social Science Research
+                                                    </p>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+
+                    <!-- Main Content -->
+                    <tr>
+                        <td style="padding: 32px 24px;">
+                            <h2 style="margin: 0 0 16px 0; font-size: 20px; font-weight: 500; color: #212121;">
+                                Hello ${user.get('firstName')} ${user.get('lastName')},
+                            </h2>
+                            <p style="margin: 0 0 16px 0; color: #212121; font-size: 16px; line-height: 1.6;">
+                                Your account has been approved. You may now login.
+                            </p>
+                            <p style="margin: 0 0 16px 0; color: #212121; font-size: 16px; line-height: 1.6;">
+                                <a href="${base_url}">${base_url}</a>
+                            </p>
+                        </td>
+                    </tr>
+
+                    <!-- Footer -->
+                    <tr>
+                        <td style="background-color: #f5f5f5; padding: 24px; text-align: center; border-top: 1px solid #e0e0e0;">
+                            <p style="margin: 0 0 8px 0; color: #757575; font-size: 12px;">
+                                This is an automated notification from SIVACOR
+                            </p>
+                            <p style="margin: 0 0 16px 0; color: #757575; font-size: 12px;">
+                                © ${current_year} SIVACOR. All rights reserved.
+                            </p>
+                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center">
+                                <tr>
+                                    <td style="padding: 0 8px;">
+                                        <a href="${base_url}" style="color: #1976d2; text-decoration: none; font-size: 12px;">Dashboard</a>
+                                    </td>
+                                    <td style="padding: 0 8px; color: #e0e0e0;">|</td>
+                                    <td style="padding: 0 8px;">
+                                        <a href="${docs_url}" style="color: #1976d2; text-decoration: none; font-size: 12px;">Documentation</a>
+                                    </td>
+                                    <td style="padding: 0 8px; color: #e0e0e0;">|</td>
+                                    <td style="padding: 0 8px;">
+                                        <a href="mailto:support@sivacor.org" style="color: #1976d2; text-decoration: none; font-size: 12px;">Support</a>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/girder_sivacor/worker_plugin/__init__.py
+++ b/girder_sivacor/worker_plugin/__init__.py
@@ -134,9 +134,18 @@ def notify_user(job, submission_folder, success: bool) -> None:
     msg, recipients = _createMessage(
         subject, text_content, rendered_html, [user["email"]], None
     )
+    events.trigger("_sendmail", info={"message": msg, "recipients": recipients})
 
+
+def _sendmail(event):
+    msg = event.info["message"]
+    recipients = event.info["recipients"]
+    _submitEmail(msg, recipients)
+
+
+def _submitEmail(msg, recipients):
     if os.environ.get("GIRDER_EMAIL_TO_CONSOLE"):
-        print("Redirecting email to console:")
+        print("[sivacor] Redirecting email to console:")
         print(msg.as_string())
         return
 
@@ -219,6 +228,8 @@ class SIVACORWorkerPlugin(GirderWorkerPluginABC):
         self.app = app
         mail_utils.addTemplateDirectory((_HERE.parent / "mail_templates").as_posix())
         events.bind("jobs.job.update.after", "sivacor", set_submission_status)
+        events.unbind("_sendmail", "core.email")
+        events.bind("_sendmail", "sivacor", _sendmail)
 
     def task_imports(self):
         return [


### PR DESCRIPTION

> [!NOTE]
> depends on not yet merged changes to vanilla girder: https://github.com/girder/girder/pull/3839 and https://github.com/girder/girder/pull/3845

Inject custom branded templates for `accountApproval` and `accountApproved` events.