### PR TITLE
Run workflows with memlimit slightly below VM's max

### DIFF
--- a/girder_sivacor/errors.py
+++ b/girder_sivacor/errors.py
@@ -44,6 +44,12 @@ class FailureCode(str, Enum):
     STATA_ERROR = "stata_error"
     #: The analysis container exited non-zero. ``detail`` is the exit code.
     NONZERO_EXIT = "nonzero_exit"
+    #: The kernel OOM-killed the analysis container's cgroup. ``detail`` is the
+    #: limit in bytes it exceeded -- a property of the worker's flavor, not of
+    #: the researcher. Distinct from NONZERO_EXIT because the exit code is an
+    #: indistinguishable 137 and the container's own logs say nothing: the
+    #: process is killed with no chance to report.
+    OUT_OF_MEMORY = "out_of_memory"
     #: The image could not be pulled. ``detail`` is the (allow-listed) image ref.
     IMAGE_PULL_FAILED = "image_pull_failed"
     #: No run command could be inferred for the image family.

--- a/girder_sivacor/telemetry.py
+++ b/girder_sivacor/telemetry.py
@@ -148,6 +148,12 @@ def _stata_detail(value):
 _DETAIL_VALIDATORS = {
     FailureCode.STATA_ERROR: _stata_detail,
     FailureCode.NONZERO_EXIT: lambda v: _safe_int(v),
+    # The memory cap the run exceeded. A machine fact -- it is derived from the
+    # worker's flavor, identically for every submission that lands on one -- so
+    # it says nothing about the researcher, and it is the number that makes the
+    # record actionable: "failed at 59 GiB" and "failed at 28 GiB" are different
+    # problems with different fixes.
+    FailureCode.OUT_OF_MEMORY: lambda v: _safe_int(v, minimum=0),
     FailureCode.MAIN_FILE_AMBIGUOUS: lambda v: _safe_int(v, minimum=0),
     FailureCode.IMAGE_PULL_FAILED: lambda v: _image_reference(v),
     FailureCode.UNSAFE_ARCHIVE: lambda v: _one_of(v, _ARCHIVE_REASONS),
@@ -179,6 +185,9 @@ def _sanitize_stage(stage):
         "exit_code": _safe_int(stage.get("exit_code")),
         "max_cpu_percent": _safe_number(stage.get("max_cpu_percent")),
         "max_memory_bytes": _safe_number(stage.get("max_memory_bytes")),
+        # The cap the run was given. Same class as image_size_bytes: a property
+        # of the worker, identical for every submission on that flavor.
+        "mem_limit_bytes": _safe_number(stage.get("mem_limit_bytes"), minimum=0),
         # Peak bytes the run's own workspace occupied, and the size of the image
         # it needed on the machine. Both are machine facts, not researcher
         # content -- an exact byte count is fine here, unlike the uploaded

--- a/girder_sivacor/worker_plugin/lib.py
+++ b/girder_sivacor/worker_plugin/lib.py
@@ -555,6 +555,56 @@ def _infer_run_command(submission, stage):
 #: job with an explanatory message.
 DISK_FLOOR_BYTES = int(os.environ.get("SIVACOR_DISK_FLOOR_BYTES", 5 * 1024**3))
 
+#: RAM held back from the analysis container, for everything else on the worker.
+#: Overridable per host with ``SIVACOR_MEMORY_HEADROOM_BYTES``.
+#:
+#: The disk story above, in memory. An analysis container was previously
+#: unlimited, so a hungry payload competed with the celery worker that supervises
+#: it -- and won. Measured on 2026-08-11: a Stata run peaked at 29.1 GB of the
+#: worker's 29.4 GB, held it for three hours with no swap, and celery's
+#: MainProcess stopped answering. The analysis finished with ``exit 0``, but
+#: nothing was left alive to advance the chain, so the submission was reaped as
+#: "no heartbeat" and the completed work was discarded.
+#:
+#: Capping the container moves the failure inside the cgroup: the kernel kills
+#: the *analysis*, the container exits, ``recorded_run`` raises
+#: :attr:`~girder_sivacor.errors.FailureCode.OUT_OF_MEMORY`, and the worker
+#: survives to report it. One clearly-explained failed submission instead of a
+#: silently lost one.
+#:
+#: 2 GiB is for celery, the docker daemon, and the OS. It is not generous; it is
+#: the smallest amount that has to survive for a failure to be *reportable*.
+MEMORY_HEADROOM_BYTES = int(
+    os.environ.get("SIVACOR_MEMORY_HEADROOM_BYTES", 2 * 1024**3)
+)
+
+#: Do not cap below this. A limit this small cannot run any analysis image, so
+#: setting one would convert "this host is too small" into a confusing
+#: out-of-memory report against the researcher's code.
+MIN_CONTAINER_MEMORY_BYTES = 2 * 1024**3
+
+
+def container_memory_limit(mem_total) -> int | None:
+    """Bytes to allow the analysis container, or ``None`` to leave it unlimited.
+
+    ``None`` on a host too small to spare the headroom: an uncapped run on a tiny
+    dev box is the status quo and merely risky, whereas a 0-byte limit would fail
+    every submission instantly.
+    """
+    if not isinstance(mem_total, int) or mem_total <= 0:
+        logging.warning("Docker reported no MemTotal; analysis container uncapped")
+        return None
+    limit = mem_total - MEMORY_HEADROOM_BYTES
+    if limit < MIN_CONTAINER_MEMORY_BYTES:
+        logging.warning(
+            "Host has %.1f GiB total, too little to reserve %.1f GiB; "
+            "analysis container uncapped",
+            mem_total / 1024**3,
+            MEMORY_HEADROOM_BYTES / 1024**3,
+        )
+        return None
+    return limit
+
 
 def directory_usage(*paths) -> int:
     """Bytes actually occupied on disk by everything under ``paths``.
@@ -859,6 +909,21 @@ def recorded_run(api, submission, stage, env_vars, task=None):
             ORPHAN_LABEL_JOB: str(submission.get("job_id", "")),
         },
     }
+    if (mem_limit := container_memory_limit(info.get("MemTotal"))) is not None:
+        container_kwargs["mem_limit"] = mem_limit
+        # Equal to mem_limit, which is how docker spells "no swap for this
+        # container". Left unset, docker allows swap up to 2x the limit, and a
+        # payload that swaps instead of dying reproduces the original failure in
+        # slow motion: the box thrashes, celery stops being scheduled, and the
+        # OOM that would have produced a clean error never arrives. The JS2
+        # workers have no swap today, so this is insurance against a host that
+        # does, not a change in behaviour on the current fleet.
+        container_kwargs["memswap_limit"] = mem_limit
+        logging.info(
+            "Analysis container capped at %.1f GiB of %.1f GiB total",
+            mem_limit / 1024**3,
+            info["MemTotal"] / 1024**3,
+        )
     container = cli.containers.create(**container_kwargs)
     # redact env in container_kwargs since we dump them later
     container_kwargs["environment"] = {
@@ -927,6 +992,10 @@ def recorded_run(api, submission, stage, env_vars, task=None):
             ret = container.wait()
 
         container.reload()
+        # Read before container.remove() further down, which takes the state with
+        # it. Docker sets this when the kernel OOM-killed the container's cgroup;
+        # the exit code is an indistinguishable 137, the same as any SIGKILL.
+        oom_killed = bool((container.attrs.get("State") or {}).get("OOMKilled"))
         logging.info(f"Container exited with status: {ret['StatusCode']}")
         logging.info("Collecting performance data...")
         performance_data.update(
@@ -977,6 +1046,11 @@ def recorded_run(api, submission, stage, env_vars, task=None):
                 "exit_code": ret.get("StatusCode"),
                 "max_cpu_percent": performance_data.get("MaxCPUPercent"),
                 "max_memory_bytes": performance_data.get("MaxMemoryUsage"),
+                # The cap this run was given, so max_memory_bytes can be read as
+                # a fraction of what was allowed rather than an absolute number.
+                # Without it, a future flavor change silently re-baselines every
+                # comparison against older records.
+                "mem_limit_bytes": mem_limit,
                 "max_disk_bytes": performance_data.get("MaxDiskUsage"),
                 "image_size_bytes": performance_data.get("ImageSize"),
             }
@@ -1100,6 +1174,24 @@ def recorded_run(api, submission, stage, env_vars, task=None):
         pass
 
     if not task.canceled:
+        # Before the generic branch: an OOM kill exits 137, which would otherwise
+        # be reported as "check stdout/stderr" -- and stdout will say nothing,
+        # because the process was killed without warning. This is the one failure
+        # whose cause is invisible from inside the container.
+        if oom_killed:
+            raise SubmissionError(
+                FailureCode.OUT_OF_MEMORY,
+                (
+                    f"The analysis used more memory than this worker allows "
+                    f"({mem_limit / 1024**3:.1f} GiB) and was stopped. Reduce the "
+                    "memory your code needs, or ask support@sivacor.org about a "
+                    "larger worker."
+                    if mem_limit is not None
+                    else "The analysis was stopped by the kernel for using too "
+                    "much memory."
+                ),
+                detail=mem_limit,
+            )
         if ret["StatusCode"] != 0:
             raise SubmissionError(
                 FailureCode.NONZERO_EXIT,

--- a/tests/test_memory_limit.py
+++ b/tests/test_memory_limit.py
@@ -1,0 +1,270 @@
+"""Capping the analysis container's memory, and reporting it when the cap bites.
+
+An analysis container used to be unlimited, which made the researcher's payload a
+competitor of the celery worker supervising it -- and on 2026-08-11 the payload
+won. A Stata run peaked at 29.1 GB of the worker's 29.4 GB, held it for three
+hours with no swap, and celery's MainProcess stopped answering. The analysis
+itself finished with ``exit 0``; nothing was left alive to advance the chain, so
+the submission was reaped as "no heartbeat" and the completed work was thrown
+away. Three submissions were lost that way over two days.
+
+The cap moves that failure inside the cgroup, where it is survivable and can be
+explained. Two things have to hold for that to be an improvement rather than a
+new way to fail, and both are tested here:
+
+* the cap must never be so small that it fails submissions a host could have run
+  (:func:`container_memory_limit` returning ``None`` beats returning nonsense);
+* an OOM kill must be reported *as* an OOM kill. Docker exits 137 for any
+  SIGKILL, and the container's own logs say nothing, because the process is
+  killed without warning -- so this is the one failure whose cause is invisible
+  from inside the container and has to be read from the daemon.
+"""
+
+import os
+import tarfile
+import tempfile
+
+import mock
+import pytest
+from girder_jobs.constants import JobStatus
+from girder_sivacor.errors import FailureCode
+from girder_sivacor.worker_plugin.lib import (
+    MEMORY_HEADROOM_BYTES,
+    MIN_CONTAINER_MEMORY_BYTES,
+    container_memory_limit,
+)
+from pytest_girder.assertions import assertStatusOk
+
+from .conftest import (
+    get_submission_folder,
+    submit_sivacor_job,
+    upload_test_file,
+)
+
+GIB = 1024**3
+
+
+# --- how much to allow -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "flavor,total",
+    [
+        ("m3.large", 61440 * 1024**2),
+        ("m3.medium", 31529943040),  # the MemTotal docker reported on 2026-08-11
+    ],
+)
+def test_cap_is_total_minus_headroom(flavor, total):
+    """The whole machine, less what has to survive to report a failure."""
+    assert container_memory_limit(total) == total - MEMORY_HEADROOM_BYTES
+
+
+def test_the_headroom_is_actually_reserved():
+    """Regression guard for the bug this exists to prevent.
+
+    The 2026-08-11 wedge needed only ~300 MB more than the box had. Whatever the
+    headroom is set to, what matters is that the difference is left unallocated.
+    """
+    total = 32 * GIB
+    assert total - container_memory_limit(total) == MEMORY_HEADROOM_BYTES
+
+
+def test_a_host_too_small_to_spare_the_headroom_is_left_uncapped():
+    """``None``, not a tiny cap.
+
+    A cap below what any analysis image needs would convert "this host is too
+    small" into an out-of-memory report against the researcher's code -- blaming
+    the submission for a property of the worker. An uncapped run on a small dev
+    box is merely the old behaviour.
+    """
+    assert container_memory_limit(3 * GIB) is None
+
+
+def test_the_floor_is_inclusive():
+    """A host with exactly enough is capped, not rejected.
+
+    Guards the boundary in both directions: one byte less must not be capped.
+    """
+    exactly_enough = MIN_CONTAINER_MEMORY_BYTES + MEMORY_HEADROOM_BYTES
+    assert container_memory_limit(exactly_enough) == MIN_CONTAINER_MEMORY_BYTES
+    assert container_memory_limit(exactly_enough - 1) is None
+
+
+@pytest.mark.parametrize("reported", [None, 0, -1, "62914560", 3.5, True])
+def test_unusable_memory_readings_leave_the_container_uncapped(reported):
+    """``docker info`` is not guaranteed to answer, and must not be guessed at.
+
+    ``True`` is in here on purpose: ``isinstance(True, int)`` is ``True`` in
+    Python, so a bool would otherwise sail through as a 1-byte host.
+    """
+    assert container_memory_limit(reported) is None
+
+
+# --- what happens when it bites ---------------------------------------------
+
+
+@pytest.mark.plugin("sivacor")
+def test_an_oom_killed_analysis_is_reported_as_one(
+    server,
+    db,
+    user,
+    eagerWorkerTasks,
+    fsAssetstore,
+    patched_gpg,
+    uploads_folder,
+    submission_collection,
+):
+    """A killed container must not surface as "check stdout/stderr".
+
+    It exits 137 like any SIGKILL and writes nothing on the way out, so without
+    reading ``State.OOMKilled`` off the daemon the researcher is told to consult
+    a log that cannot explain it. The cap is forced small here rather than
+    allocating ~60 GB to reach the real one.
+    """
+    main_file = "main.R"
+    stages = [
+        {"image_name": "rocker/r-ver", "image_tag": "4.3.1", "main_file": main_file}
+    ]
+    with (
+        tempfile.NamedTemporaryFile(suffix=".tar.gz") as temp_archive,
+        tempfile.TemporaryDirectory() as temp_dir,
+    ):
+        with open(os.path.join(temp_dir, main_file), "w") as f:
+            # Comfortably past the 256 MiB cap below, in one allocation, so the
+            # kernel kills it rather than the process degrading slowly.
+            f.write("x <- numeric(150e6)\ncat(length(x))\n")
+        with tarfile.open(temp_archive.name, "w:gz") as tar:
+            tar.add(temp_dir, arcname=".")
+        fobj = upload_test_file(uploads_folder, user, temp_archive.name)
+
+    with mock.patch(
+        "girder_sivacor.worker_plugin.lib.container_memory_limit",
+        return_value=256 * 1024**2,
+    ):
+        resp = submit_sivacor_job(server, user, fobj, stages)
+    assertStatusOk(resp)
+
+    # Re-fetch: the submit response is the job as created, so its status is
+    # always RUNNING no matter how the chain ends.
+    resp = server.request(path=f"/job/{resp.json['_id']}", method="GET", user=user)
+    assertStatusOk(resp)
+    job = resp.json
+
+    assert job["status"] == JobStatus.ERROR
+
+    log = "".join(job["log"])
+    # The message has to name memory and the actual limit. "Error executing
+    # recorded run. Check stdout/stderr for details." -- the generic non-zero
+    # branch -- would be a false lead here.
+    assert "memory" in log.lower()
+    assert "GiB" in log
+    assert "Check stdout/stderr" not in log
+
+    resp = get_submission_folder(server, user, job["_id"], submission_collection)
+    assertStatusOk(resp)
+    assert resp.json[0]["meta"]["status"] == "failed"
+
+
+@pytest.mark.plugin("sivacor")
+def test_a_run_within_its_cap_is_untouched(
+    server,
+    db,
+    user,
+    eagerWorkerTasks,
+    fsAssetstore,
+    patched_gpg,
+    uploads_folder,
+    submission_collection,
+):
+    """The cap must be invisible to a submission that fits inside it.
+
+    Worth its own test because the cheapest way to make the test above pass is a
+    limit low enough to kill everything.
+    """
+    main_file = "main.R"
+    stages = [
+        {"image_name": "rocker/r-ver", "image_tag": "4.3.1", "main_file": main_file}
+    ]
+    with (
+        tempfile.NamedTemporaryFile(suffix=".tar.gz") as temp_archive,
+        tempfile.TemporaryDirectory() as temp_dir,
+    ):
+        with open(os.path.join(temp_dir, main_file), "w") as f:
+            f.write("x <- numeric(1e6)\ncat(length(x))\n")
+        with tarfile.open(temp_archive.name, "w:gz") as tar:
+            tar.add(temp_dir, arcname=".")
+        fobj = upload_test_file(uploads_folder, user, temp_archive.name)
+
+    with mock.patch(
+        "girder_sivacor.worker_plugin.lib.container_memory_limit",
+        return_value=512 * 1024**2,
+    ):
+        resp = submit_sivacor_job(server, user, fobj, stages)
+    assertStatusOk(resp)
+
+    resp = server.request(path=f"/job/{resp.json['_id']}", method="GET", user=user)
+    assertStatusOk(resp)
+    assert resp.json["status"] == JobStatus.SUCCESS
+
+
+# --- what is kept about it ---------------------------------------------------
+
+
+def test_the_limit_survives_the_telemetry_allow_list():
+    """``mem_limit_bytes`` is what makes ``max_memory_bytes`` interpretable.
+
+    Without it a flavor change silently re-baselines every comparison against
+    older records: "peaked at 29 GB" means something different on a 30 GB worker
+    than on a 61 GB one.
+    """
+    from girder_sivacor.telemetry import sanitize_record
+
+    record = sanitize_record(
+        {
+            "status": "failed",
+            "stages": [
+                {
+                    "image_name": "rocker/r-ver",
+                    "image_tag": "4.3.1",
+                    "max_memory_bytes": 58 * GIB,
+                    "mem_limit_bytes": 59 * GIB,
+                }
+            ],
+            "error": {
+                "step": "execute_workflow",
+                "code": FailureCode.OUT_OF_MEMORY.value,
+                "detail": 59 * GIB,
+            },
+        },
+        "2026-08-11",
+    )
+
+    assert record["stages"][0]["mem_limit_bytes"] == 59 * GIB
+    assert record["error"]["code"] == "out_of_memory"
+    assert record["error"]["detail"] == 59 * GIB
+
+
+@pytest.mark.parametrize(
+    "detail", ["/home/jane/confidential.dta", -1, 3.7, None, "59 GiB"]
+)
+def test_only_a_byte_count_is_kept_as_the_failure_detail(detail):
+    """The detail is a machine fact or it is nothing.
+
+    Same reasoning as every other validator in telemetry.py: a field that
+    accepts free text is a field that will eventually carry a path.
+    """
+    from girder_sivacor.telemetry import sanitize_record
+
+    record = sanitize_record(
+        {
+            "status": "failed",
+            "stages": [],
+            "error": {
+                "step": "execute_workflow",
+                "code": FailureCode.OUT_OF_MEMORY.value,
+                "detail": detail,
+            },
+        },
+        "2026-08-11",
+    )
+    assert record["error"]["detail"] is None


### PR DESCRIPTION
By adding a hard limit to memory that can be consumed for workflow container, we can catch OOM in a more meaningful way. Hopefully, it will also prevent celery main process from dying...