### PR TITLE
Prevent worker from subscribing to main queue after restart

### DIFF
--- a/girder_sivacor/worker_plugin/run_submission.py
+++ b/girder_sivacor/worker_plugin/run_submission.py
@@ -15,7 +15,7 @@ from zoneinfo import ZoneInfo
 import pathspec
 import posix1e
 import randomname
-from celery.signals import worker_ready
+from celery.signals import celeryd_after_setup, worker_ready
 from girder.constants import AccessType
 from girder_worker.app import app
 from girder_worker.utils import JobStatus
@@ -38,6 +38,7 @@ from .routing import (
     LOCAL_QUEUE,
     configured_worker_queue,
     instance_id_of,
+    is_ephemeral_worker,
     pin_chain,
     stop_accepting_submissions,
     worker_queue,
@@ -321,6 +322,13 @@ def prepare_submission(task, userId, fileId, stages, job_id):
     # capacity, so every second this goes unrecorded is a second it may refuse to
     # create the instance the next submission needs (D8 / P3.5).
     api.claim(job_id, queue)
+    # Record the same fact where *this worker* can read it back after a restart.
+    # Written before the cancel below, because the cancel is the perishable half:
+    # it dies with the process, and a RECOVERY restart mid-chain would otherwise
+    # rejoin the dispatch queue and reserve a submission it cannot start. See
+    # _decline_dispatch_if_spent.
+    if instance_id := instance_id_of(queue):
+        _mark_spent(instance_id)
     # ...and, if this instance exists only to serve one submission, stop taking new
     # ones now. Best-effort: failing to cancel the consumer means the controller may
     # over-count headroom, which is worth a warning but never worth failing a
@@ -819,6 +827,119 @@ READY_MARKER_TTL_SECONDS = 48 * 60 * 60
 
 #: Redis key prefix for readiness markers, read by ``sivacor-autoscaler``.
 READY_KEY_PREFIX = "sivacor:ready:"
+
+#: Redis key prefix for spent markers -- "this instance has already claimed a
+#: submission". Written at claim time, read at startup by
+#: :func:`_decline_dispatch_if_spent`.
+SPENT_KEY_PREFIX = "sivacor:spent:"
+
+#: How long a spent marker lives. Generously long on purpose, because the two
+#: errors are not symmetric: an over-long marker is collected when the key expires
+#: on an instance OpenStack has already deleted, and costs nothing, while one that
+#: expires *under a running submission* re-arms the bug this marker exists to
+#: prevent. It must therefore exceed the controller's ``max_lifetime``, which
+#: production currently sets to 180 h -- not the 30 h the readiness marker's
+#: comment assumes (see the incident write-up's pre-existing hazards).
+SPENT_MARKER_TTL_SECONDS = 14 * 24 * 60 * 60
+
+
+def _mark_spent(instance: str) -> None:
+    """Record durably that this instance has claimed a submission.
+
+    ``api.claim()`` already records the same fact server-side, and the controller
+    reads *that*. This marker exists for the worker's own benefit at startup, and it
+    has to be readable by a worker that holds no Girder credential -- which is the
+    entire reason it lives in Redis next to D9's readiness marker rather than being
+    re-read from Girder. See :func:`_decline_dispatch_if_spent`.
+
+    Best effort. Failing to write it means a *restarted* worker may take a
+    submission it cannot start, which the controller's unclaimed-demand signal now
+    covers; failing the submission over it would be a much worse trade.
+    """
+    try:
+        _redis_client_sync().set(
+            f"{SPENT_KEY_PREFIX}{instance}",
+            datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            ex=SPENT_MARKER_TTL_SECONDS,
+        )
+    except Exception:
+        logger.warning(
+            "Could not write the spent marker for instance %s; if this worker is "
+            "restarted mid-chain it may accept a submission it cannot start",
+            instance,
+            exc_info=True,
+        )
+
+
+@celeryd_after_setup.connect
+def _decline_dispatch_if_spent(sender=None, instance=None, **kwargs):
+    """Never consume the dispatch queue on a worker that has already claimed.
+
+    ``stop_accepting_submissions`` drops the dispatch consumer the moment a
+    submission is claimed, which is what keeps a busy ephemeral worker out of the
+    controller's capacity count. But ``cancel_consumer`` is a **runtime control
+    message: its effect lives in the worker process and dies with it.**
+
+    Observed in production 2026-08-12. A worker 9.5 h into a four-stage submission
+    wedged; the new ``RECOVER_TICKS`` supervisor correctly restarted its celery
+    container at 04:39:36Z and the chain resumed three seconds later. The restarted
+    process subscribed to everything in ``--queues``, dispatch queue included, and
+    because the chain was mid-flight ``prepare_submission`` never ran again to
+    re-issue the cancel. Nine hours later that worker reserved the next submission's
+    head task, could not start it (``--concurrency=1``, still busy), and -- because a
+    reserved message is no longer in the Redis list -- the controller saw
+    ``depth=0`` and created nothing. The submission sat untouched until it was
+    cancelled by hand.
+
+    **Deselecting here rather than cancelling later is the point.**
+    ``routing.stop_accepting_submissions`` documents why a post-hoc cancel cannot win:
+    the first messages arrive in the worker's *initial prefetch*, milliseconds after
+    ``ready`` and before any task code exists to call it. ``celeryd_after_setup``
+    fires before the consumer starts, so a spent worker never subscribes at all and
+    there is no race to lose.
+
+    The private queue is untouched -- the whole purpose of a restart mid-chain is to
+    consume the queued next step -- so recovery still works exactly as designed.
+    """
+    if not is_ephemeral_worker():
+        # The manager's static worker is long-lived and serves many submissions.
+        return
+    queue = configured_worker_queue()
+    instance_id = instance_id_of(queue) if queue else None
+    if not instance_id:
+        return
+    try:
+        spent = bool(_redis_client_sync().exists(f"{SPENT_KEY_PREFIX}{instance_id}"))
+    except Exception:
+        # Fall through to consuming. A worker that cannot reach Redis has bigger
+        # problems, and refusing work on a *failed probe* would turn a Redis blip
+        # into an instance that can never serve anything -- the phantom D9 exists
+        # to catch. Over-counted headroom is the milder error, and the controller's
+        # unclaimed-demand signal catches its consequence.
+        logger.warning(
+            "Could not read the spent marker for instance %s; consuming %s as usual",
+            instance_id,
+            DISPATCH_QUEUE,
+            exc_info=True,
+        )
+        return
+    if not spent:
+        return
+    if instance is None:
+        logger.warning(
+            "Instance %s is spent but no worker instance was supplied; cannot "
+            "decline %s",
+            instance_id,
+            DISPATCH_QUEUE,
+        )
+        return
+    instance.app.amqp.queues.deselect(DISPATCH_QUEUE)
+    logger.warning(
+        "Instance %s already claimed a submission; not consuming %s after this "
+        "restart. Its private queue is unaffected, so the interrupted chain resumes.",
+        instance_id,
+        DISPATCH_QUEUE,
+    )
 
 
 @worker_ready.connect

--- a/tests/test_ephemeral_worker.py
+++ b/tests/test_ephemeral_worker.py
@@ -105,3 +105,121 @@ def test_private_queue_is_never_cancelled(monkeypatch, task):
     (queue,), kwargs = app.control.cancel_consumer.call_args
     assert queue == DISPATCH_QUEUE
     assert not queue.startswith(f"{DISPATCH_QUEUE}.")
+
+
+# --- surviving a restart (incident 2026-08-12) ------------------------------
+# `cancel_consumer` is a runtime control message: its effect lives in the worker
+# process and dies with it. On 2026-08-12 a worker 9.5 h into a four-stage submission
+# wedged, the RECOVER_TICKS supervisor correctly restarted its celery container, and
+# the restarted process re-subscribed to the dispatch queue -- because nothing
+# re-issues the cancel for a chain already in flight. Nine hours later it reserved a
+# submission it could not start, and the controller saw depth=0 and created nothing.
+#
+# These pin the startup half of the fix. They run without Redis: the client is mocked,
+# which is also the only way to exercise the "Redis is down" branch.
+
+from girder_sivacor.worker_plugin.run_submission import (  # noqa: E402
+    SPENT_KEY_PREFIX,
+    SPENT_MARKER_TTL_SECONDS,
+    _decline_dispatch_if_spent,
+    _mark_spent,
+)
+
+INSTANCE = "16ccbfc2-ad81-4604-9294-9bd940f8d2fb"
+QUEUE = f"sivacor.{INSTANCE}"
+
+
+@pytest.fixture
+def worker():
+    """A celery worker instance as ``celeryd_after_setup`` supplies it."""
+    return mock.MagicMock()
+
+
+@pytest.fixture
+def ephemeral(monkeypatch):
+    monkeypatch.setenv("SIVACOR_EPHEMERAL_WORKER", "1")
+    monkeypatch.setenv("SIVACOR_WORKER_QUEUE", QUEUE)
+
+
+def _redis(monkeypatch, *, spent=True, raises=False):
+    client = mock.MagicMock()
+    if raises:
+        client.exists.side_effect = RuntimeError("redis down")
+    else:
+        client.exists.return_value = 1 if spent else 0
+    monkeypatch.setattr(
+        "girder_sivacor.worker_plugin.run_submission._redis_client_sync",
+        lambda: client,
+    )
+    return client
+
+
+def test_spent_worker_declines_the_dispatch_queue_after_a_restart(
+    monkeypatch, ephemeral, worker
+):
+    client = _redis(monkeypatch, spent=True)
+    _decline_dispatch_if_spent(sender="celery@abc", instance=worker)
+    client.exists.assert_called_once_with(f"{SPENT_KEY_PREFIX}{INSTANCE}")
+    worker.app.amqp.queues.deselect.assert_called_once_with(DISPATCH_QUEUE)
+
+
+def test_the_private_queue_survives_the_decline(monkeypatch, ephemeral, worker):
+    """The point of restarting mid-chain is to consume the queued next step."""
+    _redis(monkeypatch, spent=True)
+    _decline_dispatch_if_spent(sender="celery@abc", instance=worker)
+    deselected = [c.args[0] for c in worker.app.amqp.queues.deselect.call_args_list]
+    assert QUEUE not in deselected
+
+
+def test_an_unspent_worker_keeps_consuming(monkeypatch, ephemeral, worker):
+    """A fresh instance must take work; this is the normal boot."""
+    _redis(monkeypatch, spent=False)
+    _decline_dispatch_if_spent(sender="celery@abc", instance=worker)
+    worker.app.amqp.queues.deselect.assert_not_called()
+
+
+def test_the_static_worker_never_declines(monkeypatch, worker):
+    """The manager's worker is long-lived and serves many submissions."""
+    monkeypatch.delenv("SIVACOR_EPHEMERAL_WORKER", raising=False)
+    monkeypatch.setenv("SIVACOR_WORKER_QUEUE", "sivacor.static-01")
+    client = _redis(monkeypatch, spent=True)
+    _decline_dispatch_if_spent(sender="celery@abc", instance=worker)
+    client.exists.assert_not_called()
+    worker.app.amqp.queues.deselect.assert_not_called()
+
+
+def test_unreachable_redis_keeps_consuming(monkeypatch, ephemeral, worker):
+    """Refusing work on a *failed probe* would strand the instance permanently.
+
+    Over-counted headroom is the milder error, and the controller's unclaimed-demand
+    signal catches its consequence; an instance that consumes nothing can never serve
+    anything and cannot be told apart from the D9 phantom.
+    """
+    _redis(monkeypatch, raises=True)
+    _decline_dispatch_if_spent(sender="celery@abc", instance=worker)
+    worker.app.amqp.queues.deselect.assert_not_called()
+
+
+def test_no_configured_queue_is_a_no_op(monkeypatch, worker):
+    monkeypatch.setenv("SIVACOR_EPHEMERAL_WORKER", "1")
+    monkeypatch.delenv("SIVACOR_WORKER_QUEUE", raising=False)
+    _decline_dispatch_if_spent(sender="celery@abc", instance=worker)
+    worker.app.amqp.queues.deselect.assert_not_called()
+
+
+def test_mark_spent_writes_a_key_that_outlives_the_submission(monkeypatch):
+    client = _redis(monkeypatch)
+    _mark_spent(INSTANCE)
+    (key, _), kwargs = client.set.call_args
+    assert key == f"{SPENT_KEY_PREFIX}{INSTANCE}"
+    # Must exceed the controller's max_lifetime -- production runs 180 h -- or the
+    # marker expires under a running submission and re-arms the bug.
+    assert kwargs["ex"] == SPENT_MARKER_TTL_SECONDS
+    assert SPENT_MARKER_TTL_SECONDS > 180 * 60 * 60
+
+
+def test_mark_spent_never_fails_the_submission(monkeypatch):
+    """Losing the marker costs headroom accounting, not a researcher's run."""
+    client = _redis(monkeypatch)
+    client.set.side_effect = RuntimeError("redis down")
+    _mark_spent(INSTANCE)  # must not raise


### PR DESCRIPTION
When sivacor worker recovers it needs understand it's actually running on spent node. With this PR it records it in Redis on first run, and reads it back on subsequent run if necessary.